### PR TITLE
fix(v3): fix strict mode TLS 1.3 detection bug

### DIFF
--- a/v3_client.go
+++ b/v3_client.go
@@ -85,7 +85,7 @@ func (w *streamWrapper) Read(p []byte) (n int, err error) {
 			w.readHMAC = hmac.New(sha1.New, []byte(w.password))
 			w.readHMAC.Write(w.serverRandom)
 			w.readHMACKey = kdf(w.password, w.serverRandom)
-			w.isTLS13 = isServerHelloSupportTLS13(buffer[5:])
+			w.isTLS13 = isServerHelloSupportTLS13(buffer)
 			if !w.isTLS13 {
 				w.authorized = true
 			}

--- a/v3_server.go
+++ b/v3_server.go
@@ -110,7 +110,10 @@ func isServerHelloSupportTLS13(frame []byte) bool {
 	if err != nil {
 		return false
 	}
-	for i := uint16(0); i < extensionListLength; i++ {
+	// extensionListLength is the total byte length of all extensions,
+	// NOT the number of extensions. Iterate by bytes consumed.
+	extensionsRead := uint16(0)
+	for extensionsRead < extensionListLength {
 		var extensionType uint16
 		err = binary.Read(reader, binary.BigEndian, &extensionType)
 		if err != nil {
@@ -121,6 +124,7 @@ func isServerHelloSupportTLS13(frame []byte) bool {
 		if err != nil {
 			return false
 		}
+		extensionsRead += 4 + extensionLength
 		if extensionType != 43 {
 			_, err = io.CopyN(io.Discard, reader, int64(extensionLength))
 			if err != nil {


### PR DESCRIPTION
## Summary

- **v3_server.go**: `isServerHelloSupportTLS13` treated `extensionListLength` as number of extensions instead of total byte length, causing out-of-bounds reads
- **v3_client.go**: `isServerHelloSupportTLS13` was called with `buffer[5:]` (already stripped TLS record header), but the function expected the full frame

## Bug Details

### Bug 1: Extension parsing loop (v3_server.go)
`extensionListLength` is the total byte length of all extensions, NOT the number of extensions. The original code used it as a loop counter, causing the parser to read far past the actual data.

**Fix**: Track bytes consumed with `extensionsRead` and add `4 + extensionLength` per iteration.

### Bug 2: Buffer offset (v3_client.go)
Client called `isServerHelloSupportTLS13(buffer[5:])` after stripping the 5-byte TLS record header, but the function internally uses `sessionIDLengthIndex=43` which assumes the full frame is passed.

**Fix**: Pass the full buffer instead of `buffer[5:]`.

## Testing

Tested with `cloud.tencent.com:443` (confirmed TLS 1.3) + strict mode enabled.
5/5 random string echo tests pass.