### PR TITLE
Fix v3 vectorised writes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ^1.23
+          go-version: ~1.23
       - name: Cache go module
         uses: actions/cache@v3
         with:

--- a/v3_conn.go
+++ b/v3_conn.go
@@ -121,10 +121,10 @@ func (c *verifiedConn) write(p []byte) (n int, err error) {
 	header[2] = 3
 	binary.BigEndian.PutUint16(header[3:tlsHeaderSize], hmacSize+uint16(len(p)))
 	c.access.Lock()
+	defer c.access.Unlock()
 	c.hmacAdd.Write(p)
 	hmacHash := c.hmacAdd.Sum(nil)[:hmacSize]
 	c.hmacAdd.Write(hmacHash)
-	c.access.Unlock()
 	copy(header[tlsHeaderSize:], hmacHash)
 	_, err = bufio.WriteVectorised(c.vectorisedWriter, [][]byte{header[:], p})
 	if err == nil {
@@ -135,6 +135,7 @@ func (c *verifiedConn) write(p []byte) (n int, err error) {
 
 func (c *verifiedConn) WriteBuffer(buffer *buf.Buffer) error {
 	c.access.Lock()
+	defer c.access.Unlock()
 	c.hmacAdd.Write(buffer.Bytes())
 	dateLen := buffer.Len()
 	header := buffer.ExtendHeader(tlsHmacHeaderSize)
@@ -144,26 +145,55 @@ func (c *verifiedConn) WriteBuffer(buffer *buf.Buffer) error {
 	binary.BigEndian.PutUint16(header[3:tlsHeaderSize], hmacSize+uint16(dateLen))
 	hmacHash := c.hmacAdd.Sum(nil)[:hmacSize]
 	c.hmacAdd.Write(hmacHash)
-	c.access.Unlock()
 	copy(header[tlsHeaderSize:], hmacHash)
 	return c.writer.WriteBuffer(buffer)
 }
 
 func (c *verifiedConn) WriteVectorised(buffers []*buf.Buffer) error {
+	defer buf.ReleaseMulti(buffers)
+	var payload [][]byte
+	var payloadLength int
+	for _, buffer := range buffers {
+		data := buffer.Bytes()
+		for len(data) > 0 {
+			dataLength := len(data)
+			if remaining := 16384 - payloadLength; dataLength > remaining {
+				dataLength = remaining
+			}
+			payload = append(payload, data[:dataLength])
+			payloadLength += dataLength
+			data = data[dataLength:]
+			if payloadLength == 16384 {
+				if err := c.writeVectorised(payload, payloadLength); err != nil {
+					return err
+				}
+				payload = payload[:0]
+				payloadLength = 0
+			}
+		}
+	}
+	if payloadLength > 0 {
+		return c.writeVectorised(payload, payloadLength)
+	}
+	return nil
+}
+
+func (c *verifiedConn) writeVectorised(payload [][]byte, payloadLength int) error {
 	var header [tlsHmacHeaderSize]byte
 	header[0] = applicationData
 	header[1] = 3
 	header[2] = 3
-	binary.BigEndian.PutUint16(header[3:tlsHeaderSize], hmacSize+uint16(buf.LenMulti(buffers)))
+	binary.BigEndian.PutUint16(header[3:tlsHeaderSize], hmacSize+uint16(payloadLength))
 	c.access.Lock()
-	for _, buffer := range buffers {
-		c.hmacAdd.Write(buffer.Bytes())
+	defer c.access.Unlock()
+	for _, data := range payload {
+		c.hmacAdd.Write(data)
 	}
-	c.hmacAdd.Write(c.hmacAdd.Sum(nil)[:hmacSize])
 	hmacHash := c.hmacAdd.Sum(nil)[:hmacSize]
-	c.access.Unlock()
+	c.hmacAdd.Write(hmacHash)
 	copy(header[tlsHeaderSize:], hmacHash)
-	return c.vectorisedWriter.WriteVectorised(append([]*buf.Buffer{buf.As(header[:])}, buffers...))
+	_, err := bufio.WriteVectorised(c.vectorisedWriter, append([][]byte{header[:]}, payload...))
+	return err
 }
 
 func (c *verifiedConn) FrontHeadroom() int {

--- a/v3_conn_test.go
+++ b/v3_conn_test.go
@@ -1,0 +1,222 @@
+package shadowtls
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/binary"
+	"hash"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sagernet/sing/common/buf"
+)
+
+func TestVerifiedConnWriteVectorisedPreservesPayloadAndState(t *testing.T) {
+	t.Parallel()
+
+	sender, receiver, wire := newTestVerifiedConnPair(t)
+
+	writeDone := make(chan error, 1)
+	go func() {
+		err := sender.WriteVectorised([]*buf.Buffer{
+			buf.As([]byte("vectorised ")),
+			buf.As([]byte("payload")),
+		})
+		if err == nil {
+			_, err = sender.Write([]byte(" followed by a regular write"))
+		}
+		writeDone <- err
+	}()
+
+	want := []byte("vectorised payload followed by a regular write")
+	got := make([]byte, len(want))
+	_, err := io.ReadFull(receiver, got)
+	if err != nil {
+		t.Fatalf("read payload: %v", err)
+	}
+	if err = <-writeDone; err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("payload mismatch:\n got: %q\nwant: %q", got, want)
+	}
+	assertValidApplicationDataRecords(t, wire.Bytes(), want)
+}
+
+func TestVerifiedConnWriteVectorisedSplitsLargePayload(t *testing.T) {
+	t.Parallel()
+
+	sender, receiver, wire := newTestVerifiedConnPair(t)
+
+	bufferSizes := []int{
+		0, 1, 16384, 16385, 65531, 65532,
+		65535, 65535, 65535, 65535, 65535, 65535,
+	}
+	totalSize := 0
+	for _, size := range bufferSizes {
+		totalSize += size
+	}
+	if totalSize <= 512000 {
+		t.Fatalf("test payload must exceed the vectorised copy threshold: %d", totalSize)
+	}
+	want := make([]byte, totalSize)
+	for index := range want {
+		want[index] = byte((index*31 + 7) % 251)
+	}
+	buffers := make([]*buf.Buffer, 0, len(bufferSizes))
+	offset := 0
+	for _, size := range bufferSizes {
+		bufferCapacity := size
+		if bufferCapacity == 0 {
+			bufferCapacity = 1
+		}
+		buffer := buf.NewSize(bufferCapacity)
+		if _, err := buffer.Write(want[offset : offset+size]); err != nil {
+			t.Fatal(err)
+		}
+		buffers = append(buffers, buffer)
+		offset += size
+	}
+
+	writeDone := make(chan error, 1)
+	go func() {
+		writeDone <- sender.WriteVectorised(buffers)
+	}()
+
+	got := make([]byte, len(want))
+	_, err := io.ReadFull(receiver, got)
+	if err != nil {
+		t.Fatalf("read payload: %v", err)
+	}
+	if err = <-writeDone; err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatal("payload mismatch")
+	}
+	for index, buffer := range buffers {
+		if buffer.Cap() != 0 {
+			t.Fatalf("buffer %d was not released", index)
+		}
+	}
+	assertValidApplicationDataRecords(t, wire.Bytes(), want)
+}
+
+func assertValidApplicationDataRecords(t *testing.T, wire []byte, want []byte) {
+	t.Helper()
+
+	hmacState := newTestHMAC()
+	payload := make([]byte, 0, len(want))
+	recordCount := 0
+	for len(wire) > 0 {
+		if len(wire) < tlsHeaderSize {
+			t.Fatalf("truncated TLS header: %d bytes", len(wire))
+		}
+		if wire[0] != applicationData || wire[1] != 3 || wire[2] != 3 {
+			t.Fatalf("unexpected TLS record header: %x", wire[:tlsHeaderSize])
+		}
+		recordLength := int(binary.BigEndian.Uint16(wire[3:tlsHeaderSize]))
+		if recordLength > hmacSize+16384 {
+			t.Fatalf("TLS application data record is too large: %d", recordLength)
+		}
+		fullLength := tlsHeaderSize + recordLength
+		if len(wire) < fullLength {
+			t.Fatalf("truncated TLS record: have %d bytes, want %d", len(wire), fullLength)
+		}
+		recordHMAC := wire[tlsHeaderSize:tlsHmacHeaderSize]
+		recordPayload := wire[tlsHmacHeaderSize:fullLength]
+		hmacState.Write(recordPayload)
+		wantHMAC := hmacState.Sum(nil)[:hmacSize]
+		if !hmac.Equal(recordHMAC, wantHMAC) {
+			t.Fatalf("record %d HMAC mismatch: got %x, want %x", recordCount, recordHMAC, wantHMAC)
+		}
+		hmacState.Write(wantHMAC)
+		payload = append(payload, recordPayload...)
+		wire = wire[fullLength:]
+		recordCount++
+	}
+	if !bytes.Equal(payload, want) {
+		t.Fatal("wire payload mismatch")
+	}
+	if len(want) > 16384 && recordCount < 2 {
+		t.Fatalf("payload was not split: %d record", recordCount)
+	}
+}
+
+func newTestVerifiedConnPair(t *testing.T) (*verifiedConn, *verifiedConn, *recordingConn) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	acceptDone := make(chan struct {
+		conn net.Conn
+		err  error
+	}, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		acceptDone <- struct {
+			conn net.Conn
+			err  error
+		}{conn, acceptErr}
+	}()
+	left, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		listener.Close()
+		t.Fatal(err)
+	}
+	accepted := <-acceptDone
+	listener.Close()
+	if accepted.err != nil {
+		left.Close()
+		t.Fatal(accepted.err)
+	}
+	right := accepted.conn
+	deadline := time.Now().Add(5 * time.Second)
+	if err := left.SetDeadline(deadline); err != nil {
+		t.Fatal(err)
+	}
+	if err := right.SetDeadline(deadline); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		left.Close()
+		right.Close()
+	})
+
+	recordingLeft := &recordingConn{Conn: left}
+	return newVerifiedConn(recordingLeft, newTestHMAC(), newTestHMAC(), nil),
+		newVerifiedConn(right, newTestHMAC(), newTestHMAC(), nil), recordingLeft
+}
+
+func newTestHMAC() hash.Hash {
+	hmacHash := hmac.New(sha1.New, []byte("test password"))
+	hmacHash.Write([]byte("test server random"))
+	hmacHash.Write([]byte("S"))
+	return hmacHash
+}
+
+type recordingConn struct {
+	net.Conn
+	access sync.Mutex
+	writes bytes.Buffer
+}
+
+func (c *recordingConn) Write(p []byte) (int, error) {
+	n, err := c.Conn.Write(p)
+	c.access.Lock()
+	c.writes.Write(p[:n])
+	c.access.Unlock()
+	return n, err
+}
+
+func (c *recordingConn) Bytes() []byte {
+	c.access.Lock()
+	defer c.access.Unlock()
+	return bytes.Clone(c.writes.Bytes())
+}


### PR DESCRIPTION
## Summary

- generate the ShadowTLS v3 rolling HMAC before appending it to the state
- split and coalesce vectorised payloads into TLS records with at most 16 KiB of payload while preserving scatter/gather writes
- serialize each HMAC state transition with its corresponding wire write
- add regression coverage for payloads above 512 KB, record boundaries, rolling-state continuity, and input-buffer ownership
- pin the lint workflow to Go 1.23, matching `.golangci.yml`, so the floating toolchain cannot outrun the linter binary

## Root cause

`verifiedConn.WriteVectorised` appended the current digest (`H1`) to the rolling state and then calculated and emitted the next digest (`H2`) in the TLS record header. The peer calculates `H1` for that record, rejects the mismatch, sends an alert, and closes the connection on the first vectorised write.

This becomes especially visible when `sing` switches to vectorised copying after 512,000 bytes. The same implementation also encoded the whole batch length into one `uint16` TLS record length, so sufficiently large batches could wrap the length field or exceed the intended record payload size.

## CI compatibility

`actions/setup-go` currently resolves `^1.23` to Go 1.26.5, while `golangci-lint-action@v3` resolves `latest` to golangci-lint v1.64.8, which was built with Go 1.24. That combination fails while type-checking the Go 1.26 standard library before it checks this repository. Since `.golangci.yml` explicitly targets Go 1.23, the workflow now uses `~1.23`.

## Tests

The new tests exercise the public connection behavior and independently parse the bytes written on the wire; they do not rely on the production HMAC implementation to validate itself.

- `make test` on macOS with Go 1.20.14 and Go 1.23.12
- `make test` in official Linux containers with Go 1.20.14, 1.21.13, 1.22.12, and 1.23.12
- `go test -race -count=100 ./...`
- `make lint`
- Go 1.21.13 and Go 1.22.12 Linux/amd64 test binaries compile locally
- [GitHub-hosted test matrix](https://github.com/SunsetWan/sing-shadowtls/actions/runs/29930664246): Linux, Go 1.20/1.21/1.22, macOS, and Windows passed
- [GitHub-hosted lint](https://github.com/SunsetWan/sing-shadowtls/actions/runs/29930660698): passed with the pinned Go 1.23 toolchain

Both final runs used tree `081ba5e19507c394ea74a9a77145cf2dec92dc0e`, which is identical to this PR's head tree.
